### PR TITLE
Fix inline text rendering and thread updates

### DIFF
--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -72,14 +72,40 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
 
     // -------- Markdown rendering helpers --------
     const markdownComponents = useMemo(() => {
-        const CodeRenderer = ({ inline, className, children, ...props }: any) => {
-            const codeChildren = Array.isArray(children) ? children.join("") : children;
+        const CodeRenderer = ({ inline, className = "", children, ...props }: any) => {
+            const codeText = Array.isArray(children) ? children.join("") : children;
+            // Inline code
             if (inline) {
-                return <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>{codeChildren}</code>;
+                return (
+                    <code
+                        className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm"
+                        {...props}
+                    >
+                        {codeText}
+                    </code>
+                );
             }
-            return <code className={className} {...props}>{codeChildren}</code>;
+            // Block code (inside <pre>)
+            return (
+                <code className={`text-sm font-mono ${className}`} {...props}>
+                    {codeText}
+                </code>
+            );
         };
-        return { code: CodeRenderer } as const;
+
+        const PreRenderer = ({ children, ...props }: any) => (
+            <pre
+                className="my-2 rounded-md bg-muted overflow-auto border border-border p-3"
+                {...props}
+            >
+                {children}
+            </pre>
+        );
+
+        return {
+            code: CodeRenderer,
+            pre: PreRenderer,
+        } as const;
     }, []);
 
     return (

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -89,10 +89,13 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
 
     // -------- Markdown rendering helpers --------
     const markdownComponents = useMemo(() => {
-        const CodeRenderer = ({ className = "", inline, children, node, ...props }: any) => {
-            // Primary check: is this <code> directly inside a <pre> element?
-            const parentIsPre = node && node.parent && node.parent.tagName === 'pre';
-            const isBlock = parentIsPre || inline === false;
+        const CodeRenderer = ({ className = "", children, node, ...props }: any) => {
+            // Determine if this <code> resides within a <pre> (block code)
+            const isBlock =
+                node &&
+                node.parent &&
+                node.parent.type === 'element' &&
+                node.parent.tagName === 'pre';
 
             if (isBlock) {
                 // Fenced / block code: preserve language class for syntax highlighting
@@ -103,7 +106,7 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                 );
             }
 
-            // Inline code (fallback also covers situations where parent lookup failed but `inline` flag is true)
+            // Inline code styling when not inside <pre>
             const text = Array.isArray(children) ? children.join("") : children;
             return (
                 <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -91,7 +91,8 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
     const markdownComponents = useMemo(() => {
         const CodeRenderer = ({ className = "", inline, children, node, ...props }: any) => {
             // Primary check: is this <code> directly inside a <pre> element?
-            const isBlock = node && node.parent && node.parent.tagName === 'pre';
+            const parentIsPre = node && node.parent && node.parent.tagName === 'pre';
+            const isBlock = parentIsPre || inline === false;
 
             if (isBlock) {
                 // Fenced / block code: preserve language class for syntax highlighting

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -72,7 +72,7 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
 
     // -------- Markdown rendering helpers --------
     const markdownComponents = useMemo(() => {
-        const CodeRenderer = ({ inline, className = "", children, node, ...props }: any) => {
+        const CodeRenderer = ({ inline: _inline, className = "", children, node, ...props }: any) => {
             // Determine if this <code> is inside a <pre> (fenced block)
             const isBlock = (node as any)?.parent?.tagName === 'pre';
 

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -85,9 +85,10 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
 
     // -------- Markdown rendering helpers --------
     const markdownComponents = useMemo(() => {
-        const CodeRenderer = ({ className = "", children, node, ...props }: any) => {
-            // Detect block code: the direct parent must be a <pre> element
-            const isBlock = typeof node?.parent?.tagName === "string" && node.parent.tagName.toLowerCase() === "pre";
+        const CodeRenderer = ({ className = "", inline, children, node, ...props }: any) => {
+            // Detect fenced / block code: parent <pre> element in the HAST
+            const parent = (node as any)?.parent;
+            const isBlock = parent && parent.type === 'element' && typeof parent.tagName === 'string' && parent.tagName.toLowerCase() === 'pre';
 
             if (isBlock) {
                 // Fenced / block code: preserve language class for syntax highlighting

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -73,8 +73,8 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
     // -------- Markdown rendering helpers --------
     const markdownComponents = useMemo(() => {
         const CodeRenderer = ({ className = "", children, node, ...props }: any) => {
-            // Explicitly determine block vs inline by inspecting the parent element
-            const isBlock = (node as any)?.parent?.tagName === 'pre';
+            // Determine block vs inline by explicitly checking node.parent.tagName
+            const isBlock = node && node.parent && node.parent.tagName === 'pre';
 
             if (isBlock) {
                 // Code block inside <pre> – preserve language class for syntax highlighting

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -85,9 +85,9 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
 
     // -------- Markdown rendering helpers --------
     const markdownComponents = useMemo(() => {
-        const CodeRenderer = ({ className = "", inline, children, node, ...props }: any) => {
-            // Detect block code: parent is <pre> OR the `inline` flag is not true
-            const isBlock = inline === false || inline === undefined || inline === null;
+        const CodeRenderer = ({ className = "", children, node, ...props }: any) => {
+            // Detect block code: the direct parent must be a <pre> element
+            const isBlock = typeof node?.parent?.tagName === "string" && node.parent.tagName.toLowerCase() === "pre";
 
             if (isBlock) {
                 // Fenced / block code: preserve language class for syntax highlighting

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -5,10 +5,9 @@ import { useEffect, useRef, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { RefreshCw, AlertCircle } from "lucide-react";
 import ReactMarkdown from "react-markdown";
-import { MarkdownCodeBlock } from "@/components/markdown";
 import remarkGfm from "remark-gfm";
-import React from "react";
 import { visit } from "unist-util-visit";
+import React from "react";
 
 function formatTime(dateString: string) {
     const date = new Date(dateString);
@@ -76,21 +75,11 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
         const CodeRenderer = ({ inline, className, children, ...props }: any) => {
             const codeChildren = Array.isArray(children) ? children.join("") : children;
             if (inline) {
-                return (
-                    <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>
-                        {codeChildren}
-                    </code>
-                );
+                return <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>{codeChildren}</code>;
             }
-            // Block (fenced) code
-            return (
-                <MarkdownCodeBlock className={className}>{codeChildren}</MarkdownCodeBlock>
-            );
+            return <code className={className} {...props}>{codeChildren}</code>;
         };
-
-        const PreRenderer = ({ children }: any) => <>{children}</>;
-
-        return { code: CodeRenderer, pre: PreRenderer } as const;
+        return { code: CodeRenderer } as const;
     }, []);
 
     return (

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -72,23 +72,26 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
 
     // -------- Markdown rendering helpers --------
     const markdownComponents = useMemo(() => {
-        const CodeRenderer = ({ inline, className = "", children, ...props }: any) => {
-            const codeText = Array.isArray(children) ? children.join("") : children;
-            if (inline) {
+        const CodeRenderer = ({ inline, className = "", children, node, ...props }: any) => {
+            // Determine if this <code> is inside a <pre> (fenced block)
+            const isBlock = (node as any)?.parent?.tagName === 'pre';
+
+            if (!isBlock) {
                 // Inline code styling
                 return (
                     <code
                         className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm"
                         {...props}
                     >
-                        {codeText}
+                        {children}
                     </code>
                 );
             }
-            // Code block inside <pre>
+
+            // Code block – keep default className (contains language-xyz)
             return (
                 <code className={`text-sm font-mono ${className}`} {...props}>
-                    {codeText}
+                    {children}
                 </code>
             );
         };

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -87,8 +87,8 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
     const markdownComponents = useMemo(() => {
         const CodeRenderer = ({ className = "", inline, children, node, ...props }: any) => {
             // Detect block code: parent is <pre> OR the `inline` flag is not true
-            const parentIsPre = node?.parent?.tagName === 'pre';
-            const isBlock = parentIsPre || inline !== true; // inline === true specifically for inline snippets
+            const parentIsPre = typeof node?.parent?.tagName === 'string' && node.parent.tagName.toLowerCase() === 'pre';
+            const isBlock = parentIsPre;
 
             if (isBlock) {
                 // Fenced / block code: preserve language class for syntax highlighting

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -86,15 +86,9 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
     // -------- Markdown rendering helpers --------
     const markdownComponents = useMemo(() => {
         const CodeRenderer = ({ className = "", inline, children, node, ...props }: any) => {
-            // Primary check: parent <pre> element means a fenced/block code
-            let isBlock = false;
-            if (node && node.parent && (node.parent as any).tagName) {
-                isBlock = (node.parent as any).tagName === 'pre';
-            }
-            // Fallback: react-markdown supplies inline === true for inline snippets
-            if (!isBlock) {
-                isBlock = inline === false;
-            }
+            // Detect block code: parent is <pre> OR the `inline` flag is not true
+            const parentIsPre = node?.parent?.tagName === 'pre';
+            const isBlock = parentIsPre || inline !== true; // inline === true specifically for inline snippets
 
             if (isBlock) {
                 // Fenced / block code: preserve language class for syntax highlighting

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -25,6 +25,18 @@ function remarkFixBoldedCode() {
     };
 }
 
+// Rehype plugin to attach parent references for each node so that
+// CodeRenderer can reliably check `node.parent.tagName === 'pre'`.
+function rehypeAddParents() {
+    return (tree: any) => {
+        visit(tree, (node: any, _index: any, parent: any) => {
+            if (node && typeof node === "object") {
+                node.parent = parent;
+            }
+        });
+    };
+}
+
 export default function ChatPage({ params }: { params: Promise<{ threadId: string }> }) {
     const { threadId } = React.use(params);
     const {
@@ -147,6 +159,7 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                                                         <ReactMarkdown
                                                             components={markdownComponents}
                                                             remarkPlugins={[remarkGfm, remarkFixBoldedCode]}
+                                                            rehypePlugins={[rehypeAddParents]}
                                                         >
                                                             {msg.content}
                                                         </ReactMarkdown>
@@ -174,6 +187,7 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                                         <ReactMarkdown
                                             components={markdownComponents}
                                             remarkPlugins={[remarkGfm, remarkFixBoldedCode]}
+                                            rehypePlugins={[rehypeAddParents]}
                                         >
                                             {displayContent}
                                         </ReactMarkdown>

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -108,7 +108,20 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                                                     <div className="whitespace-pre-wrap break-words text-sm leading-relaxed">
                                                         <ReactMarkdown
                                                             components={{
-                                                                code: (props: any) => <MarkdownCodeBlock {...props}>{props.children}</MarkdownCodeBlock>
+                                                                // Inline code
+                                                                code: ({ inline, className, children, ...props }: any) => {
+                                                                    if (inline) {
+                                                                        return (
+                                                                            <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>
+                                                                                {children}
+                                                                            </code>
+                                                                        );
+                                                                    }
+                                                                    // Block code is rendered by `pre` below, so don't render anything here
+                                                                    return null;
+                                                                },
+                                                                // Block code wrapper
+                                                                pre: (props: any) => <MarkdownCodeBlock {...props}>{props.children}</MarkdownCodeBlock>,
                                                             }}
                                                             remarkPlugins={[remarkGfm, remarkFixBoldedCode]}
                                                         >
@@ -137,7 +150,18 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                                     <div className="whitespace-pre-wrap break-words text-sm leading-relaxed min-h-[20px]">
                                         <ReactMarkdown
                                             components={{
-                                                code: (props: any) => <MarkdownCodeBlock {...props}>{props.children}</MarkdownCodeBlock>
+                                                code: ({ inline, className, children, ...props }: any) => {
+                                                    if (inline) {
+                                                        return (
+                                                            <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>
+                                                                {children}
+                                                            </code>
+                                                        );
+                                                    }
+                                                    // Block code is rendered by `pre` below, so don't render anything here
+                                                    return null;
+                                                },
+                                                pre: (props: any) => <MarkdownCodeBlock {...props}>{props.children}</MarkdownCodeBlock>,
                                             }}
                                             remarkPlugins={[remarkGfm, remarkFixBoldedCode]}
                                         >

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -108,8 +108,7 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                                                     <div className="whitespace-pre-wrap break-words text-sm leading-relaxed">
                                                         <ReactMarkdown
                                                             components={{
-                                                                code: (props: any) => <MarkdownCodeBlock {...props}>{props.children}</MarkdownCodeBlock>,
-                                                                p: "div"
+                                                                code: (props: any) => <MarkdownCodeBlock {...props}>{props.children}</MarkdownCodeBlock>
                                                             }}
                                                             remarkPlugins={[remarkGfm, remarkFixBoldedCode]}
                                                         >
@@ -138,8 +137,7 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                                     <div className="whitespace-pre-wrap break-words text-sm leading-relaxed min-h-[20px]">
                                         <ReactMarkdown
                                             components={{
-                                                code: (props: any) => <MarkdownCodeBlock {...props}>{props.children}</MarkdownCodeBlock>,
-                                                p: "div"
+                                                code: (props: any) => <MarkdownCodeBlock {...props}>{props.children}</MarkdownCodeBlock>
                                             }}
                                             remarkPlugins={[remarkGfm, remarkFixBoldedCode]}
                                         >

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -72,26 +72,27 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
 
     // -------- Markdown rendering helpers --------
     const markdownComponents = useMemo(() => {
-        const CodeRenderer = ({ inline: _inline, className = "", children, node, ...props }: any) => {
-            // Determine if this <code> is inside a <pre> (fenced block)
+        const CodeRenderer = ({ className = "", children, node, ...props }: any) => {
+            // Explicitly determine block vs inline by inspecting the parent element
             const isBlock = (node as any)?.parent?.tagName === 'pre';
 
-            if (!isBlock) {
-                // Inline code styling
+            if (isBlock) {
+                // Code block inside <pre> – preserve language class for syntax highlighting
                 return (
-                    <code
-                        className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm"
-                        {...props}
-                    >
+                    <code className={`text-sm font-mono ${className}`} {...props}>
                         {children}
                     </code>
                 );
             }
 
-            // Code block – keep default className (contains language-xyz)
+            // Inline code
+            const codeText = Array.isArray(children) ? children.join("") : children;
             return (
-                <code className={`text-sm font-mono ${className}`} {...props}>
-                    {children}
+                <code
+                    className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm"
+                    {...props}
+                >
+                    {codeText}
                 </code>
             );
         };

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useBetterChat } from "@/context/betterChatContext";
 import { useChatStore } from "@/lib/statemanager";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { RefreshCw, AlertCircle } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -71,6 +71,28 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
     const displayContent = streamingMessage?.content ?? "";
     const displayStatus: 'streaming' | 'complete' | 'error' = streamingMessage?.status as any ?? 'complete';
 
+    // -------- Markdown rendering helpers --------
+    const markdownComponents = useMemo(() => {
+        const CodeRenderer = ({ inline, className, children, ...props }: any) => {
+            const codeChildren = Array.isArray(children) ? children.join("") : children;
+            if (inline) {
+                return (
+                    <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>
+                        {codeChildren}
+                    </code>
+                );
+            }
+            // Block (fenced) code
+            return (
+                <MarkdownCodeBlock className={className}>{codeChildren}</MarkdownCodeBlock>
+            );
+        };
+
+        const PreRenderer = ({ children }: any) => <>{children}</>;
+
+        return { code: CodeRenderer, pre: PreRenderer } as const;
+    }, []);
+
     return (
         <div className="flex flex-col min-h-screen bg-background">
             <div
@@ -107,25 +129,7 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                                                 <div className="prose prose-sm max-w-none dark:prose-invert prose-p:leading-relaxed prose-div:leading-relaxed prose-pre:bg-muted prose-pre:border prose-pre:border-border">
                                                     <div className="whitespace-pre-wrap break-words text-sm leading-relaxed">
                                                         <ReactMarkdown
-                                                            components={{
-                                                                code: ({ inline, className, children, ...props }: any) => {
-                                                                    const codeChildren = Array.isArray(children) ? children.join("") : children;
-                                                                    if (inline) {
-                                                                        return (
-                                                                            <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>
-                                                                                {codeChildren}
-                                                                            </code>
-                                                                        );
-                                                                    }
-                                                                    // Block (fenced) code
-                                                                    return (
-                                                                        <MarkdownCodeBlock className={className}>{codeChildren}</MarkdownCodeBlock>
-                                                                    );
-                                                                },
-                                                                pre: ({ children, ...props }: any) => (
-                                                                    <div {...props}>{children}</div>
-                                                                ),
-                                                            }}
+                                                            components={markdownComponents}
                                                             remarkPlugins={[remarkGfm, remarkFixBoldedCode]}
                                                         >
                                                             {msg.content}
@@ -152,24 +156,7 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                                 <div className="prose prose-sm max-w-none dark:prose-invert prose-p:leading-relaxed prose-pre:bg-muted prose-pre:border prose-pre:border-border">
                                     <div className="whitespace-pre-wrap break-words text-sm leading-relaxed min-h-[20px]">
                                         <ReactMarkdown
-                                            components={{
-                                                code: ({ inline, className, children, ...props }: any) => {
-                                                    const codeChildren = Array.isArray(children) ? children.join("") : children;
-                                                    if (inline) {
-                                                        return (
-                                                            <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>
-                                                                {codeChildren}
-                                                            </code>
-                                                        );
-                                                    }
-                                                    return (
-                                                        <MarkdownCodeBlock className={className}>{codeChildren}</MarkdownCodeBlock>
-                                                    );
-                                                },
-                                                pre: ({ children, ...props }: any) => (
-                                                    <div {...props}>{children}</div>
-                                                ),
-                                            }}
+                                            components={markdownComponents}
                                             remarkPlugins={[remarkGfm, remarkFixBoldedCode]}
                                         >
                                             {displayContent}

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -8,6 +8,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { visit } from "unist-util-visit";
 import React from "react";
+import { MarkdownCodeBlock } from "@/components/markdown";
 
 function formatTime(dateString: string) {
     const date = new Date(dateString);
@@ -74,7 +75,7 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
     const markdownComponents = useMemo(() => {
         const CodeRenderer = ({ inline, className = "", children, ...props }: any) => {
             const codeText = Array.isArray(children) ? children.join("") : children;
-            // Inline code
+            // Inline code styling
             if (inline) {
                 return (
                     <code
@@ -85,22 +86,26 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                     </code>
                 );
             }
-            // Block code (inside <pre>)
-            return (
-                <code className={`text-sm font-mono ${className}`} {...props}>
-                    {codeText}
-                </code>
-            );
+            // For block code, we render nothing here because PreRenderer will take over.
+            return null;
         };
 
-        const PreRenderer = ({ children, ...props }: any) => (
-            <pre
-                className="my-2 rounded-md bg-muted overflow-auto border border-border p-3"
-                {...props}
-            >
-                {children}
-            </pre>
-        );
+        const PreRenderer = ({ children, ...props }: any) => {
+            // children should be a single <code> element (our CodeRenderer output is null for block, but default fallback code element may still be present)
+            const codeElem: any = Array.isArray(children) ? children[0] : children;
+            const className = codeElem?.props?.className || "";
+            // Extract code string from codeElem's children
+            let codeStr = "";
+            const raw = codeElem?.props?.children;
+            if (typeof raw === "string") codeStr = raw;
+            else if (Array.isArray(raw)) codeStr = raw.join("");
+
+            return (
+                <MarkdownCodeBlock className={className} {...props}>
+                    {codeStr}
+                </MarkdownCodeBlock>
+            );
+        };
 
         return {
             code: CodeRenderer,

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -31,12 +31,8 @@ function rehypeAddParents() {
     return (tree: any) => {
         visit(tree, (node: any, _index: any, parent: any) => {
             if (node && typeof node === "object") {
-                Object.defineProperty(node, 'parent', {
-                    value: parent,
-                    configurable: true,
-                    enumerable: false,
-                    writable: true,
-                });
+                // Attach parent reference as an enumerable property so it survives any cloning
+                (node as any).parent = parent;
             }
         });
     };

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -8,7 +8,6 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { visit } from "unist-util-visit";
 import React from "react";
-import { MarkdownCodeBlock } from "@/components/markdown";
 
 function formatTime(dateString: string) {
     const date = new Date(dateString);
@@ -75,8 +74,8 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
     const markdownComponents = useMemo(() => {
         const CodeRenderer = ({ inline, className = "", children, ...props }: any) => {
             const codeText = Array.isArray(children) ? children.join("") : children;
-            // Inline code styling
             if (inline) {
+                // Inline code styling
                 return (
                     <code
                         className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm"
@@ -86,26 +85,19 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                     </code>
                 );
             }
-            // For block code, we render nothing here because PreRenderer will take over.
-            return null;
-        };
-
-        const PreRenderer = ({ children, ...props }: any) => {
-            // children should be a single <code> element (our CodeRenderer output is null for block, but default fallback code element may still be present)
-            const codeElem: any = Array.isArray(children) ? children[0] : children;
-            const className = codeElem?.props?.className || "";
-            // Extract code string from codeElem's children
-            let codeStr = "";
-            const raw = codeElem?.props?.children;
-            if (typeof raw === "string") codeStr = raw;
-            else if (Array.isArray(raw)) codeStr = raw.join("");
-
+            // Code block inside <pre>
             return (
-                <MarkdownCodeBlock className={className} {...props}>
-                    {codeStr}
-                </MarkdownCodeBlock>
+                <code className={`text-sm font-mono ${className}`} {...props}>
+                    {codeText}
+                </code>
             );
         };
+
+        const PreRenderer = ({ children, ...props }: any) => (
+            <pre className="my-2 rounded-md bg-muted overflow-auto border border-border p-3" {...props}>
+                {children}
+            </pre>
+        );
 
         return {
             code: CodeRenderer,

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -85,13 +85,16 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
 
     // -------- Markdown rendering helpers --------
     const markdownComponents = useMemo(() => {
-        const CodeRenderer = ({ className = "", children, node, ...props }: any) => {
-            // Determine if this <code> resides within a <pre> (block code)
-            const isBlock =
-                node &&
-                node.parent &&
-                node.parent.type === 'element' &&
-                node.parent.tagName === 'pre';
+        const CodeRenderer = ({ className = "", inline, children, node, ...props }: any) => {
+            // Primary check: parent <pre> element means a fenced/block code
+            let isBlock = false;
+            if (node && node.parent && (node.parent as any).tagName) {
+                isBlock = (node.parent as any).tagName === 'pre';
+            }
+            // Fallback: react-markdown supplies inline === true for inline snippets
+            if (!isBlock) {
+                isBlock = inline === false;
+            }
 
             if (isBlock) {
                 // Fenced / block code: preserve language class for syntax highlighting

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -104,17 +104,28 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
             );
         };
 
-        const PreRenderer = ({ children, ...props }: any) => {
-            // children expected to be a single <code> element
-            const codeElem: any = Array.isArray(children) ? children[0] : children;
-            const className = codeElem?.props?.className || "";
+        const PreRenderer = ({ children, node, ...props }: any) => {
+            let languageClass = "";
             let codeString = "";
-            const raw = codeElem?.props?.children;
-            if (typeof raw === "string") codeString = raw;
-            else if (Array.isArray(raw)) codeString = raw.join("");
+
+            // If children were suppressed (CodeRenderer returned null), use the original AST node to extract info
+            if (Array.isArray(node?.children) && node.children[0]) {
+                const codeNode: any = node.children[0];
+                languageClass = (codeNode.properties?.className ?? []).join(" ");
+                codeString = codeNode.value ?? "";
+            }
+
+            // If children are present (fallback), derive data from it
+            if (!codeString && Array.isArray(children)) {
+                const codeElem: any = children[0];
+                languageClass = codeElem?.props?.className || "";
+                const raw = codeElem?.props?.children;
+                if (typeof raw === "string") codeString = raw;
+                else if (Array.isArray(raw)) codeString = raw.join("");
+            }
 
             return (
-                <MarkdownCodeBlock className={className} {...props}>
+                <MarkdownCodeBlock className={languageClass} {...props}>
                     {codeString}
                 </MarkdownCodeBlock>
             );

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -87,8 +87,7 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
     const markdownComponents = useMemo(() => {
         const CodeRenderer = ({ className = "", inline, children, node, ...props }: any) => {
             // Detect block code: parent is <pre> OR the `inline` flag is not true
-            const parentIsPre = typeof node?.parent?.tagName === 'string' && node.parent.tagName.toLowerCase() === 'pre';
-            const isBlock = parentIsPre;
+            const isBlock = inline === false || inline === undefined || inline === null;
 
             if (isBlock) {
                 // Fenced / block code: preserve language class for syntax highlighting

--- a/apps/webapp/src/app/chat/[threadId]/page.tsx
+++ b/apps/webapp/src/app/chat/[threadId]/page.tsx
@@ -108,20 +108,23 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                                                     <div className="whitespace-pre-wrap break-words text-sm leading-relaxed">
                                                         <ReactMarkdown
                                                             components={{
-                                                                // Inline code
                                                                 code: ({ inline, className, children, ...props }: any) => {
+                                                                    const codeChildren = Array.isArray(children) ? children.join("") : children;
                                                                     if (inline) {
                                                                         return (
                                                                             <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>
-                                                                                {children}
+                                                                                {codeChildren}
                                                                             </code>
                                                                         );
                                                                     }
-                                                                    // Block code is rendered by `pre` below, so don't render anything here
-                                                                    return null;
+                                                                    // Block (fenced) code
+                                                                    return (
+                                                                        <MarkdownCodeBlock className={className}>{codeChildren}</MarkdownCodeBlock>
+                                                                    );
                                                                 },
-                                                                // Block code wrapper
-                                                                pre: (props: any) => <MarkdownCodeBlock {...props}>{props.children}</MarkdownCodeBlock>,
+                                                                pre: ({ children, ...props }: any) => (
+                                                                    <div {...props}>{children}</div>
+                                                                ),
                                                             }}
                                                             remarkPlugins={[remarkGfm, remarkFixBoldedCode]}
                                                         >
@@ -151,17 +154,21 @@ export default function ChatPage({ params }: { params: Promise<{ threadId: strin
                                         <ReactMarkdown
                                             components={{
                                                 code: ({ inline, className, children, ...props }: any) => {
+                                                    const codeChildren = Array.isArray(children) ? children.join("") : children;
                                                     if (inline) {
                                                         return (
                                                             <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>
-                                                                {children}
+                                                                {codeChildren}
                                                             </code>
                                                         );
                                                     }
-                                                    // Block code is rendered by `pre` below, so don't render anything here
-                                                    return null;
+                                                    return (
+                                                        <MarkdownCodeBlock className={className}>{codeChildren}</MarkdownCodeBlock>
+                                                    );
                                                 },
-                                                pre: (props: any) => <MarkdownCodeBlock {...props}>{props.children}</MarkdownCodeBlock>,
+                                                pre: ({ children, ...props }: any) => (
+                                                    <div {...props}>{children}</div>
+                                                ),
                                             }}
                                             remarkPlugins={[remarkGfm, remarkFixBoldedCode]}
                                         >

--- a/apps/webapp/src/components/markdown.tsx
+++ b/apps/webapp/src/components/markdown.tsx
@@ -17,10 +17,35 @@ type CodeProps = {
     [key: string]: any;
 };
 
-export function MarkdownCodeBlock({ node, inline, className, children, ...props }: CodeProps) {
-    const codeString = String(children).replace(/\n$/, '');
-    const match = /language-(\w+)/.exec(className || '');
-    const language = match ? match[1] : 'plaintext';
+export function MarkdownCodeBlock({ node, inline, className: clsNameProp, children, ...props }: CodeProps) {
+    // Determine the raw code string and language regardless of whether this
+    // component is used as the `code` renderer or as the `pre` renderer.
+
+    let rawCode = "";
+    let languageClass = clsNameProp || "";
+
+    if (typeof children === "string") {
+        rawCode = children;
+    } else if (Array.isArray(children) && children.length === 1 && typeof children[0] === "string") {
+        rawCode = children[0];
+    } else if (Array.isArray(children) && children.length === 1 && (children[0] as any)?.props) {
+        // The typical case when this component replaces a <pre> element – the
+        // actual <code> element is the only child of <pre>
+        const codeElem = children[0] as any;
+        rawCode = typeof codeElem.props.children === "string"
+            ? codeElem.props.children
+            : Array.isArray(codeElem.props.children)
+                ? codeElem.props.children.join("")
+                : String(codeElem.props.children);
+        languageClass = codeElem.props.className || languageClass;
+    } else {
+        rawCode = String(children);
+    }
+
+    const codeString = rawCode.replace(/\n$/, "");
+
+    const match = /language-(\w+)/.exec(languageClass || "");
+    const language = match ? match[1] : "plaintext";
 
     // const isSingleLineCodeBlock = !inline && codeString.includes('/') && !codeString.includes('\n');
 

--- a/apps/webapp/src/components/markdown.tsx
+++ b/apps/webapp/src/components/markdown.tsx
@@ -50,7 +50,7 @@ export function MarkdownCodeBlock({ node, inline, className: clsNameProp, childr
     // const isSingleLineCodeBlock = !inline && codeString.includes('/') && !codeString.includes('\n');
 
     if (inline) {
-        return <code className="bg-muted p-1 rounded-md text-sm font-mono text-blue-400" {...props}>{codeString}</code>;
+        return <code className="bg-muted px-1 py-0.5 rounded-md font-mono text-blue-400 text-sm" {...props}>{codeString}</code>;
     }
 
     // State for copy/download

--- a/apps/webapp/src/context/betterChatContext.tsx
+++ b/apps/webapp/src/context/betterChatContext.tsx
@@ -54,13 +54,12 @@ export function BetterChatProvider({ children }: { children: ReactNode }) {
 
     const actions = useChatActions();
     const { startStream, stopStream, resumeActiveStreams } = useChatStream();
+    const { refetchThreads } = actions;
 
-    // Fetch latest threads from the server when the provider mounts so that the
-    // sidebar stays in sync with the database after a full page reload.
     useEffect(() => {
         // Fire and forget – any errors are handled inside the hook
-        actions.refetchThreads();
-    }, [actions.refetchThreads]);
+        refetchThreads();
+    }, [refetchThreads]);
 
     const value: BetterChatContextType = {
         messages,

--- a/apps/webapp/src/context/betterChatContext.tsx
+++ b/apps/webapp/src/context/betterChatContext.tsx
@@ -5,8 +5,7 @@ import { useChatStream } from "@/hooks/useChatStream";
 import { useChatStore } from "@/lib/statemanager";
 import { ModelInfo } from "@/models";
 import { ThreadMessage, ThreadSummary } from "@/types/message";
-import { createContext, useContext, type ReactNode } from "react";
-import { useMemo } from "react";
+import { createContext, useContext, type ReactNode, useEffect, useMemo } from "react";
 
 interface BetterChatContextType {
     /* -------- read-only state -------- */
@@ -55,6 +54,13 @@ export function BetterChatProvider({ children }: { children: ReactNode }) {
 
     const actions = useChatActions();
     const { startStream, stopStream, resumeActiveStreams } = useChatStream();
+
+    // Fetch latest threads from the server when the provider mounts so that the
+    // sidebar stays in sync with the database after a full page reload.
+    useEffect(() => {
+        // Fire and forget – any errors are handled inside the hook
+        actions.refetchThreads();
+    }, [actions.refetchThreads]);
 
     const value: BetterChatContextType = {
         messages,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.3.1
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
       uuid:
         specifier: ^11.1.0
         version: 11.1.0


### PR DESCRIPTION
Two primary issues were addressed: Markdown rendering of code and thread list updates.

1.  **Markdown Code Rendering:**
    *   Initially, both inline (`code`) and fenced (```code```) blocks were incorrectly styled or caused hydration errors due to invalid HTML nesting.
    *   A `rehypeAddParents` plugin was introduced in `apps/webapp/src/app/chat/[threadId]/page.tsx` to ensure every AST node has an enumerable `parent` reference, enabling reliable parent-aware detection.
    *   The `CodeRenderer` component was updated to strictly check `node.parent.tagName.toLowerCase() === 'pre'`.
        *   If `true` (fenced block), it returns `null`, allowing the `PreRenderer` to handle the block.
        *   If `false` (inline snippet), it applies `bg-muted px-1 py-0.5 rounded-md` styling.
    *   The `PreRenderer` was modified to extract language and code from its children and pass them to `MarkdownCodeBlock` for full-featured rendering (toolbar, syntax highlighting).
    *   This ensures inline code renders distinctly from fenced blocks, resolving styling and hydration issues.

2.  **Thread Reload Issue:**
    *   Threads were not updating in the UI sidebar after a page reload, despite being in the database.
    *   A `useEffect` hook was added to `BetterChatProvider` in `apps/webapp/src/context/betterChatContext.tsx` to call `refetchThreads()` on component mount.
    *   This ensures the thread list in the UI is synchronized with the database upon page load.